### PR TITLE
Add Jest setup and basic form validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "krishna-dhulipalla.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <form id="nn-contact-form" action="/" method="POST">
+      <input type="text" id="name" name="name" />
+      <input type="email" id="email" name="email" />
+      <textarea id="message" name="message"></textarea>
+      <div class="loss-message hidden" id="loss-message"></div>
+      <button type="submit" id="submit-btn"></button>
+    </form>
+  `;
+  jest.resetModules();
+  require('../js/scripts');
+});
+
+test('empty form shows loss message and prevents fetch', () => {
+  const fetchSpy = jest.spyOn(global, 'fetch');
+  const form = document.getElementById('nn-contact-form');
+  const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+  form.dispatchEvent(submitEvent);
+
+  const loss = document.getElementById('loss-message');
+  expect(loss.classList.contains('hidden')).toBe(false);
+  expect(fetchSpy).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add npm `jest` setup using jsdom
- create `tests/scripts.test.js` for form validation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c644a5d948322949b82c3ee0c50c0