### PR TITLE
Redesign portfolio with Tailwind and dark mode

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,24 @@
+# Style Guide
+
+## Typography
+- **Headings:** `Poppins`, sans-serif
+- **Body:** `Inter`, sans-serif
+
+## Color Palette
+- **Primary:** `#0d9488` (teal)
+- **Secondary:** `#f59e0b` (amber)
+- **Dark Background:** `#111827`
+- **Light Background:** `#ffffff`
+- **Text Dark:** `#1f2937`
+- **Text Light:** `#f9fafb`
+
+## Components
+- **Buttons:**
+  - Primary: `bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded`
+  - Secondary: `border border-teal-600 text-teal-600 hover:bg-teal-50 px-4 py-2 rounded`
+- **Cards:**
+  - `bg-white dark:bg-gray-800 rounded shadow p-6`
+- **Timeline:**
+  - Use `border-l-2 border-teal-600 pl-4` for vertical timeline items.
+
+This guide ensures visual consistency across the portfolio pages.

--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Resume - Krishna Vamsi Dhulipalla</title>
+    <title>About - Krishna Vamsi Dhulipalla</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
@@ -26,20 +26,26 @@
     </nav>
 
     <section class="py-16 px-6 md:px-12">
-      <h1 class="text-4xl font-bold mb-6">Resume</h1>
-      <p class="mb-8 max-w-3xl">ML Engineer with 3+ years designing intelligent systems, deploying models and integrating backend infrastructure. Skilled in LLMs, data engineering and cloud-native deployments.</p>
-      <a href="assets/resume.pdf" class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow">Download PDF</a>
-
-      <h2 class="text-2xl font-bold mt-12 mb-4">Experience Highlights</h2>
-      <ul class="list-disc ml-6 space-y-2 max-w-3xl">
-        <li>ML Research Engineer, Cloud Systems LLC – built SQL and data pipelines and automated ETL workflows.</li>
-        <li>ML Research Engineer, Virginia Tech – implemented DNA foundation models and automated preprocessing for massive genomic datasets.</li>
-        <li>Research Assistant, Virginia Tech – orchestrated genomic ETL pipelines and CI/CD for model retraining.</li>
-        <li>Data Engineer, UJR Technologies – migrated ETL to real-time streaming and optimized Snowflake schemas.</li>
+      <h1 class="text-4xl font-bold mb-6">About Me</h1>
+      <p class="max-w-3xl mb-6 leading-relaxed">
+        I'm Krishna Vamsi Dhulipalla, a data engineer and machine learning enthusiast currently pursuing my MEng in Computer Science at
+        Virginia Tech. I love building systems that turn raw data into intelligent applications.
+      </p>
+      <p class="max-w-3xl mb-6 leading-relaxed">
+        My recent work spans AI research, data engineering, and deploying cloud-native ML solutions. I'm especially fascinated by the
+        intersection of AI with space exploration and bioinformatics, pushing the boundaries of how machine learning can drive
+        scientific discovery.
+      </p>
+      <h2 class="text-2xl font-bold mt-12 mb-4">Education</h2>
+      <ul class="list-disc ml-6 space-y-2">
+        <li>M.S. in Computer Science, Virginia Tech (2023–2024)</li>
+        <li>Bachelor's in Computer Science, Anna University (2018–2022)</li>
       </ul>
-
-      <h2 class="text-2xl font-bold mt-12 mb-4">Core Skills</h2>
-      <p class="max-w-3xl">Python, SQL, Spark, Airflow, Kafka, Docker, AWS, Hugging Face, LangChain, PyTorch, TensorFlow, dbt.</p>
+      <h2 class="text-2xl font-bold mt-12 mb-4">Interests</h2>
+      <p class="max-w-3xl leading-relaxed">
+        AI systems, space technologies, and bioinformatics research excite me. When I'm not coding, I enjoy exploring new gadgets and
+        following advances in aerospace.
+      </p>
     </section>
 
     <footer class="py-6 text-center text-sm bg-white dark:bg-gray-900">

--- a/assets/resume.pdf
+++ b/assets/resume.pdf
@@ -1,0 +1,12 @@
+%PDF-1.1
+1 0 obj
+<<>>
+endobj
+xref
+0 1
+0000000000 65535 f 
+trailer
+<<>>
+startxref
+0
+%%EOF

--- a/index.html
+++ b/index.html
@@ -1,542 +1,141 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
   <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta
-      name="google-site-verification"
-      content="qCeAap7TkXSuUZxvLUJ4y7XeuWX39M39Eo62k3zbyuE"
-    />
-    <meta name="description" content="" />
-    <meta name="author" content="" />
-    <title>Krishna's Portfolio</title>
-    <!-- Favicon-->
-    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
-    <!-- Custom Google font-->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Krishna Vamsi Dhulipalla</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@100;200;300;400;500;600;700;800;900&amp;display=swap"
-      rel="stylesheet"
-    />
-    <!-- Bootstrap icons-->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css"
-      rel="stylesheet"
-    />
-    <!-- Core theme CSS (includes Bootstrap)-->
-    <link href="css/styles.css" rel="stylesheet" />
-    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
-    <script
-      src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
-      type="module"
-    ></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="js/theme.js"></script>
+    <style>
+      .animate-gradient{background-size:400% 400%;animation:gradient 15s ease infinite;}@keyframes gradient{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}
+      body{font-family:'Inter',sans-serif;}
+      h1,h2,h3,h4{font-family:'Poppins',sans-serif;}
+    </style>
   </head>
-  <body class="d-flex flex-column h-100">
-    <main class="flex-shrink-0">
-      <!-- Navigation-->
-      <nav
-        class="navbar navbar-expand-lg navbar-light bg-white py-3"
-        style="position: sticky; top: 0; z-index: 2"
-      >
-        <div class="container px-5">
-          <a class="navbar-brand" href="index.html"
-            ><span class="fw-bolder text-primary">Portfolio</span></a
-          >
-          <button
-            class="navbar-toggler"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-              <li class="nav-item">
-                <a class="nav-link" href="index.html">Home</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="resume.html">Resume</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="projects.html">Projects</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="contact.html">Contact</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-      <!-- Header-->
-      <header class="py-5">
-        <div class="container px-5 pb-5">
-          <div class="row gx-5 align-items-center">
-            <div class="col-xxl-5">
-              <!-- Header text content-->
-              <div class="text-center text-xxl-start">
-                <div
-                  class="badge bg-gradient-primary-to-secondary text-white mb-4"
-                >
-                  <div class="text-uppercase">
-                    Code &middot; Train &middot; Deploy
-                  </div>
-                </div>
-                <div class="fs-3 fw-light text-muted">
-                  Building ML tools to simplify
-                </div>
-                <h1 class="display-3 fw-bolder mb-5">
-                  <span class="text-gradient d-inline"
-                    >Real-world problems</span
-                  >
-                </h1>
-                <div
-                  class="d-grid gap-3 d-sm-flex justify-content-sm-center justify-content-xxl-start mb-3"
-                >
-                  <a
-                    class="btn btn-primary btn-lg px-5 py-3 me-sm-3 fs-6 fw-bolder"
-                    href="resume.html"
-                    >Resume</a
-                  >
-                  <a
-                    class="btn btn-outline-dark btn-lg px-5 py-3 fs-6 fw-bolder"
-                    href="projects.html"
-                    >Projects</a
-                  >
-                </div>
-              </div>
-            </div>
-            <div class="col-xxl-7">
-              <!-- Header profile picture-->
-              <div class="d-flex justify-content-center mt-5 mt-xxl-0">
-                <div class="profile bg-gradient-primary-to-secondary">
-                  <!-- TIP: For best results, use a photo with a transparent background like the demo example below-->
-                  <!-- Watch a tutorial on how to do this on YouTube (link)-->
-                  <img class="profile-img" src="assets/profile.png" alt="..." />
-                  <div class="dots-1">
-                    <!-- SVG Dots-->
-                    <svg
-                      version="1.1"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                      x="0px"
-                      y="0px"
-                      viewBox="0 0 191.6 1215.4"
-                      style="enable-background: new 0 0 191.6 1215.4"
-                      xml:space="preserve"
-                    >
-                      <g
-                        transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)"
-                      >
-                        <path
-                          d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"
-                        ></path>
-                      </g>
-                    </svg>
-                    <!-- END of SVG dots-->
-                  </div>
-                  <div class="dots-2">
-                    <!-- SVG Dots-->
-                    <svg
-                      version="1.1"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                      x="0px"
-                      y="0px"
-                      viewBox="0 0 191.6 1215.4"
-                      style="enable-background: new 0 0 191.6 1215.4"
-                      xml:space="preserve"
-                    >
-                      <g
-                        transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)"
-                      >
-                        <path
-                          d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"
-                        ></path>
-                      </g>
-                    </svg>
-                    <!-- END of SVG dots-->
-                  </div>
-                  <div class="dots-3">
-                    <!-- SVG Dots-->
-                    <svg
-                      version="1.1"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                      x="0px"
-                      y="0px"
-                      viewBox="0 0 191.6 1215.4"
-                      style="enable-background: new 0 0 191.6 1215.4"
-                      xml:space="preserve"
-                    >
-                      <g
-                        transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)"
-                      >
-                        <path
-                          d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"
-                        ></path>
-                      </g>
-                    </svg>
-                    <!-- END of SVG dots-->
-                  </div>
-                  <div class="dots-4">
-                    <!-- SVG Dots-->
-                    <svg
-                      version="1.1"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                      x="0px"
-                      y="0px"
-                      viewBox="0 0 191.6 1215.4"
-                      style="enable-background: new 0 0 191.6 1215.4"
-                      xml:space="preserve"
-                    >
-                      <g
-                        transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)"
-                      >
-                        <path
-                          d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"
-                        ></path>
-                        <path
-                          d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"
-                        ></path>
-                        <path
-                          d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"
-                        ></path>
-                        <path
-                          d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"
-                        ></path>
-                        <path
-                          d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"
-                        ></path>
-                        <path
-                          d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"
-                        ></path>
-                        <path
-                          d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"
-                        ></path>
-                        <path
-                          d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"
-                        ></path>
-                        <path
-                          d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"
-                        ></path>
-                        <path
-                          d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"
-                        ></path>
-                        <path
-                          d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"
-                        ></path>
-                      </g>
-                    </svg>
-                    <!-- END of SVG dots-->
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
-      <!-- About Section-->
-      <section class="bg-light py-5">
-        <div class="container px-5">
-          <div class="row gx-5 justify-content-center">
-            <div class="col-xxl-8">
-              <div class="text-center my-5">
-                <h2 class="display-5 fw-bolder">
-                  <span class="text-gradient d-inline">About Me</span>
-                </h2>
-                <p class="lead fw-light mb-4">
-                  My name is Krishna Vamsi Dhulipalla and Builds AI Systems That
-                  Scale.
-                </p>
-                <p class="text-muted">
-                  I'm currently a Research Assistant at Virginia Tech, working
-                  on genomic AI and large language models, while recently
-                  completing my Master's in Computer Science (Dec 2024) with a
-                  3.9/4 GPA. With 3+ years of professional experience, I
-                  specialize in:
-                </p>
-                <p
-                  class="text-muted"
-                  style="text-align: left; margin-left: 3rem"
-                >
-                  → <strong>Generative AI</strong>: Production-grade RAG
-                  systems, LLM fine-tuning, and synthetic data generation<br />
-                  → <strong>Data Engineering</strong>: Real-time ETL pipelines
-                  (Spark/Kafka), cloud-native architectures (AWS/GCP), and
-                  distributed systems<br />
-                  → <strong>ML Deployment</strong>: Containerized AI solutions
-                  (Docker/K8s), model optimization, and MLOps workflows
-                </p>
-                <p class="text-muted">
-                  My work bridges cutting-edge research with industrial
-                  applications - from developing automated drone image analysis
-                  for agriculture to implementing privacy-preserving federated
-                  learning systems. I thrive on building data infrastructure
-                  that empowers AI innovation.
-                </p>
-                <div class="d-flex justify-content-center fs-2 gap-4">
-                  <a
-                    class="text-gradient"
-                    href="mailto:dhulipallakrishnavamsi@gmail.com"
-                    ><i class="bi bi-envelope-fill"></i
-                  ></a>
-                  <a
-                    class="text-gradient"
-                    href="https://www.linkedin.com/in/krishnavamsidhulipalla/"
-                    ><i class="bi bi-linkedin"></i
-                  ></a>
-                  <a
-                    class="text-gradient"
-                    href="https://github.com/krishna-dhulipalla"
-                    ><i class="bi bi-github"></i
-                  ></a>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            id="chatbot-lottie-btn"
-            onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/ChatBot', '_blank')"
-          >
-            <dotlottie-player
-              src="https://lottie.host/12b60265-5eef-4309-bcce-98abdae08afb/9FFDxA63EF.lottie"
-              background="transparent"
-              speed="1"
-              style="width: 50px; height: 50px"
-              loop
-              autoplay
-            ></dotlottie-player>
-            <div id="chatbot-lottie-btn-text">
-              Stuck scrolling? Chat with me instead!
-            </div>
-          </div>
-        </div>
-      </section>
-    </main>
-    <!-- Footer-->
-    <footer class="bg-white py-4 mt-auto">
-      <div class="container px-5">
-        <div
-          class="row align-items-center justify-content-between flex-column flex-sm-row"
-        >
-          <div class="col-auto">
-            <div class="small m-0">Copyright &copy; Krishna 2025</div>
-          </div>
-          <div class="col-auto">
-            <a class="small" href="contact.html">Contact</a>
-          </div>
+  <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-200">
+    <nav class="flex items-center justify-between py-4 px-6 md:px-12 bg-white dark:bg-gray-900 shadow">
+      <a href="index.html" class="text-2xl font-bold text-teal-600 dark:text-teal-400">Krishna</a>
+      <div class="space-x-4 text-sm md:text-base">
+        <a href="about.html" class="hover:text-teal-600 dark:hover:text-teal-400">About</a>
+        <a href="projects.html" class="hover:text-teal-600 dark:hover:text-teal-400">Projects</a>
+        <a href="resume.html" class="hover:text-teal-600 dark:hover:text-teal-400">Resume</a>
+        <a href="contact.html" class="hover:text-teal-600 dark:hover:text-teal-400">Contact</a>
+        <button id="theme-toggle" class="ml-2 px-2 py-1 border rounded border-gray-300 dark:border-gray-600">🌓</button>
+      </div>
+    </nav>
+
+    <!-- Hero -->
+    <section class="relative flex items-center justify-center text-center py-24">
+      <div class="absolute inset-0 -z-10 animate-gradient bg-gradient-to-r from-teal-500 via-purple-500 to-teal-500 opacity-20"></div>
+      <div class="px-4">
+        <h1 class="text-4xl md:text-6xl font-bold">Krishna Vamsi Dhulipalla</h1>
+        <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Data Engineer & ML Enthusiast</p>
+        <p class="mt-2 text-gray-500 dark:text-gray-400">Building scalable data systems and AI models with impact.</p>
+        <div class="mt-8">
+          <a href="projects.html" class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow">View Projects</a>
+          <a href="resume.html" class="ml-4 border border-teal-600 text-teal-600 dark:text-teal-400 hover:bg-teal-50 dark:hover:bg-gray-800 px-6 py-3 rounded">Resume</a>
         </div>
       </div>
+    </section>
+
+    <!-- About -->
+    <section id="about" class="py-16 px-6 md:px-12">
+      <h2 class="text-3xl font-bold mb-6">About Me</h2>
+      <p class="max-w-3xl leading-relaxed">
+        I'm a graduate student pursuing an MEng in Computer Science at Virginia Tech. My work focuses on building robust data
+        pipelines and intelligent systems. I'm passionate about AI, space and bioinformatics research, and love turning complex
+        data challenges into scalable solutions.
+      </p>
+    </section>
+
+    <!-- Skills -->
+    <section id="skills" class="py-16 px-6 md:px-12 bg-gray-50 dark:bg-gray-800">
+      <h2 class="text-3xl font-bold mb-6 text-center">Skills & Tools</h2>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 max-w-4xl mx-auto">
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Python</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">SQL</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Spark</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Airflow</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Docker</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">AWS</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Hugging Face</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">LangChain</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">PyTorch</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">TensorFlow</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Kafka</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">dbt</div>
+      </div>
+    </section>
+
+    <!-- Experience -->
+    <section id="experience" class="py-16 px-6 md:px-12">
+      <h2 class="text-3xl font-bold mb-6">Experience</h2>
+      <div class="space-y-8">
+        <div class="border-l-2 border-teal-600 pl-4">
+          <h3 class="text-xl font-semibold">ML Research Engineer – Cloud Systems LLC</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Jul 2024 – Present</p>
+          <p>Designed complex SQL and data pipelines, building automated ETL workflows for diverse sources.</p>
+        </div>
+        <div class="border-l-2 border-teal-600 pl-4">
+          <h3 class="text-xl font-semibold">ML Research Engineer – Virginia Tech</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400">2024</p>
+          <p>Built AI pipelines with DNA foundation models and automated preprocessing for 1M+ sequences.</p>
+        </div>
+        <div class="border-l-2 border-teal-600 pl-4">
+          <h3 class="text-xl font-semibold">Research Assistant – Virginia Tech</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Jun 2023 – May 2024</p>
+          <p>Orchestrated genomic ETL pipelines and automated model retraining with custom CI/CD scripts.</p>
+        </div>
+        <div class="border-l-2 border-teal-600 pl-4">
+          <h3 class="text-xl font-semibold">Data Engineer – UJR Technologies</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Jul 2021 – Dec 2022</p>
+          <p>Migrated batch ETL to real-time streaming and optimized Snowflake performance with materialized views.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Projects preview -->
+    <section id="projects" class="py-16 px-6 md:px-12 bg-gray-50 dark:bg-gray-800">
+      <h2 class="text-3xl font-bold mb-6 text-center">Featured Projects</h2>
+      <div class="grid md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4">
+          <img src="https://via.placeholder.com/400x250?text=Android+Agent" alt="Android Agent" class="rounded mb-4" />
+          <h3 class="text-xl font-semibold mb-2">LLM-Based Android Agent</h3>
+          <p class="text-sm">Custom LLM agent achieving 80%+ step accuracy for mobile UI task automation.</p>
+        </div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4">
+          <img src="https://via.placeholder.com/400x250?text=Proxy+TuNER" alt="Proxy TuNER" class="rounded mb-4" />
+          <h3 class="text-xl font-semibold mb-2">Proxy TuNER</h3>
+          <p class="text-sm">Proxy-tuned BERT models improving NER F1-score by 8% while cutting compute 70%.</p>
+        </div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4">
+          <img src="https://via.placeholder.com/400x250?text=IntelliMeet" alt="IntelliMeet" class="rounded mb-4" />
+          <h3 class="text-xl font-semibold mb-2">IntelliMeet</h3>
+          <p class="text-sm">Decentralized video conferencing with on-device attention tracking and low latency.</p>
+        </div>
+      </div>
+      <div class="text-center mt-8">
+        <a href="projects.html" class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow">All Projects</a>
+      </div>
+    </section>
+
+    <!-- Resume callout -->
+    <section id="resume" class="py-16 px-6 md:px-12">
+      <h2 class="text-3xl font-bold mb-6 text-center">Resume</h2>
+      <p class="max-w-2xl mx-auto text-center mb-6">Download my full resume or view a condensed version.</p>
+      <div class="text-center">
+        <a href="assets/resume.pdf" class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow">Download Resume</a>
+      </div>
+    </section>
+
+    <footer class="py-6 text-center text-sm bg-white dark:bg-gray-900">
+      © <span id="year"></span> Krishna Vamsi Dhulipalla
     </footer>
-    <!-- Bootstrap core JS-->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Core theme JS-->
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
   </body>
 </html>

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,21 @@
+function toggleTheme() {
+  const root = document.documentElement;
+  const isDark = root.classList.contains('dark');
+  if (isDark) {
+    root.classList.remove('dark');
+    localStorage.theme = 'light';
+  } else {
+    root.classList.add('dark');
+    localStorage.theme = 'dark';
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.theme === 'dark') {
+    document.documentElement.classList.add('dark');
+  }
+  const toggle = document.getElementById('theme-toggle');
+  if (toggle) {
+    toggle.addEventListener('click', toggleTheme);
+  }
+});

--- a/projects.html
+++ b/projects.html
@@ -1,505 +1,71 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
   <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="description" content="" />
-    <meta name="author" content="" />
-    <title>Krishna's Portfolio</title>
-    <!-- Favicon-->
-    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
-    <!-- Custom Google font-->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Projects - Krishna Vamsi Dhulipalla</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@100;200;300;400;500;600;700;800;900&amp;display=swap"
-      rel="stylesheet"
-    />
-    <!-- Bootstrap icons-->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css"
-      rel="stylesheet"
-    />
-    <!-- Core theme CSS (includes Bootstrap)-->
-    <link href="css/styles.css" rel="stylesheet" />
-    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
-    <script
-      src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
-      type="module"
-    ></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="js/theme.js"></script>
+    <style>
+      body{font-family:'Inter',sans-serif;}h1,h2,h3,h4{font-family:'Poppins',sans-serif;}
+    </style>
   </head>
-  <body class="d-flex flex-column h-100 bg-light">
-    <main class="flex-shrink-0">
-      <!-- Navigation-->
-      <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
-        <div class="container px-5">
-          <a class="navbar-brand" href="index.html"
-            ><span class="fw-bolder text-primary">Portfolio</span></a
-          >
-          <button
-            class="navbar-toggler"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-              <li class="nav-item">
-                <a class="nav-link" href="index.html">Home</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="resume.html">Resume</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="projects.html">Projects</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="contact.html">Contact</a>
-              </li>
-            </ul>
-          </div>
+  <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-200">
+    <nav class="flex items-center justify-between py-4 px-6 md:px-12 bg-white dark:bg-gray-900 shadow">
+      <a href="index.html" class="text-2xl font-bold text-teal-600 dark:text-teal-400">Krishna</a>
+      <div class="space-x-4 text-sm md:text-base">
+        <a href="about.html" class="hover:text-teal-600 dark:hover:text-teal-400">About</a>
+        <a href="projects.html" class="hover:text-teal-600 dark:hover:text-teal-400">Projects</a>
+        <a href="resume.html" class="hover:text-teal-600 dark:hover:text-teal-400">Resume</a>
+        <a href="contact.html" class="hover:text-teal-600 dark:hover:text-teal-400">Contact</a>
+        <button id="theme-toggle" class="ml-2 px-2 py-1 border rounded border-gray-300 dark:border-gray-600">🌓</button>
+      </div>
+    </nav>
+
+    <section class="py-16 px-6 md:px-12">
+      <h1 class="text-4xl font-bold text-center mb-12">Projects</h1>
+      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
+        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
+          <img src="https://via.placeholder.com/400x250?text=Android+Agent" alt="Android Agent" class="rounded mb-4" />
+          <h2 class="text-2xl font-semibold mb-2">LLM-Based Android Agent</h2>
+          <p class="flex-grow">Android UI automation agent with modular prompting and memory, reaching 80%+ step accuracy.</p>
+          <a href="https://github.com/Krishna-dhulipalla" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
         </div>
-      </nav>
-      <!-- Projects Section-->
-      <section class="py-5">
-        <div class="container px-5 mb-5">
-          <div class="text-center mb-5">
-            <h1 class="display-5 fw-bolder mb-0">
-              <span class="text-gradient d-inline">Featured Projects</span>
-            </h1>
-          </div>
-          <div class="row gx-5 justify-content-center">
-            <!-- Project 1 -->
-            <div class="col-lg-8 col-xl-6 mb-5">
-              <div
-                class="card h-100 shadow-lg rounded-4 border-0 overflow-hidden"
-              >
-                <img
-                  src="assets/proxy.png"
-                  class="card-img-top img-fluid"
-                  alt="Proxy TuNER Project"
-                  style="height: 250px; object-fit: cover"
-                />
-                <div class="card-body p-4">
-                  <div
-                    class="badge bg-primary bg-gradient-primary-to-secondary text-white rounded-pill mb-2"
-                  >
-                    NLP Research
-                  </div>
-                  <h2 class="fw-bolder mb-3">
-                    Proxy TuNER: Cross-Domain NER Framework
-                  </h2>
-
-                  <div class="d-flex gap-2 mb-3">
-                    <span class="badge bg-light text-dark border">PyTorch</span>
-                    <span class="badge bg-light text-dark border">BERT</span>
-                    <span class="badge bg-light text-dark border"
-                      >HuggingFace</span
-                    >
-                  </div>
-
-                  <div class="mb-4">
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-speedometer2 me-2 text-primary"></i>
-                      <strong>30% Faster Inference</strong>
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-graph-up me-2 text-primary"></i>
-                      <strong>8% F1-Score Improvement</strong>
-                    </div>
-                    <div class="d-flex align-items-center">
-                      <i class="bi bi-cash-coin me-2 text-primary"></i>
-                      <strong>25% Cost Reduction</strong>
-                    </div>
-                  </div>
-
-                  <p class="text-muted">
-                    Advanced proxy-tuning framework for BERT models enabling:
-                  </p>
-                  <ul class="text-muted small">
-                    <li>Domain adaptation without weight modification</li>
-                    <li>71% avg F1-score across multiple domains</li>
-                    <li>Distributed training optimizations</li>
-                    <li>Automated hyperparameter tuning</li>
-                  </ul>
-
-                  <div class="mt-auto">
-                    <a
-                      href="https://github.com/krishna-creator/ProxytuNER"
-                      class="btn btn-primary px-3 py-2 me-2"
-                    >
-                      <i class="bi bi-github me-1"></i> View Code
-                    </a>
-                    <a
-                      href="https://figshare.com/articles/journal_contribution/Proxy_TuNER_Advancing_Cross-Domain_NamedEntity_Recognition_through_Proxy_Tuning/26822227/1"
-                      class="btn btn-outline-primary px-3 py-2"
-                    >
-                      Case Study
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Project 2 -->
-            <div class="col-lg-8 col-xl-6 mb-5">
-              <div
-                class="card h-100 shadow-lg rounded-4 border-0 overflow-hidden"
-              >
-                <img
-                  src="assets/drone.jpg"
-                  class="card-img-top img-fluid"
-                  alt="Drone Analysis Project"
-                  style="height: 250px; object-fit: cover"
-                />
-                <div class="card-body p-4">
-                  <div
-                    class="badge bg-primary bg-gradient-primary-to-secondary text-white rounded-pill mb-2"
-                  >
-                    Computer Vision
-                  </div>
-                  <h2 class="fw-bolder mb-3">Automated Drone Image Analysis</h2>
-
-                  <div class="d-flex gap-2 mb-3">
-                    <span class="badge bg-light text-dark border">OpenCV</span>
-                    <span class="badge bg-light text-dark border">GANs</span>
-                    <span class="badge bg-light text-dark border">RAG</span>
-                  </div>
-
-                  <div class="mb-4">
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-clock me-2 text-primary"></i>
-                      <strong>70% Time Reduction</strong>
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-patch-check me-2 text-primary"></i>
-                      <strong>15% Accuracy Boost</strong>
-                    </div>
-                  </div>
-
-                  <p class="text-muted">
-                    End-to-end pipeline for agricultural analysis:
-                  </p>
-                  <ul class="text-muted small">
-                    <li>LLM-based plant classification</li>
-                    <li>Synthetic data generation with GANs</li>
-                    <li>500+ species analysis capability</li>
-                    <li>Real-time drone image processing</li>
-                  </ul>
-
-                  <!-- <div class="mt-auto">
-                    <a href="#" class="btn btn-primary px-3 py-2 me-2">
-                      <i class="bi bi-github me-1"></i> View Code
-                    </a>
-                    <a href="#" class="btn btn-outline-primary px-3 py-2">
-                      Live Demo
-                    </a>
-                  </div> -->
-                </div>
-              </div>
-            </div>
-            <!-- Project 3 - IoT Temperature Analytics -->
-            <div class="col-lg-8 col-xl-6 mb-5">
-              <div
-                class="card h-100 shadow-lg rounded-4 border-0 overflow-hidden"
-              >
-                <img
-                  src="assets/iot.png"
-                  class="card-img-top img-fluid"
-                  alt="IoT Temperature Analytics"
-                  style="height: 250px; object-fit: cover"
-                />
-                <div class="card-body p-4">
-                  <div
-                    class="badge bg-primary bg-gradient-primary-to-secondary text-white rounded-pill mb-2"
-                  >
-                    IoT Analytics
-                  </div>
-                  <h2 class="fw-bolder mb-3">
-                    Real-Time Temperature Forecasting System
-                  </h2>
-
-                  <div class="d-flex gap-2 mb-3">
-                    <span class="badge bg-light text-dark border"
-                      >Apache Kafka</span
-                    >
-                    <span class="badge bg-light text-dark border">GPT-4</span>
-                    <span class="badge bg-light text-dark border"
-                      >Snowflake</span
-                    >
-                  </div>
-
-                  <div class="mb-4">
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-thermometer-high me-2 text-primary"></i>
-                      <strong>10,000+ IoT Sensors</strong>
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-speedometer me-2 text-primary"></i>
-                      <strong>91% Prediction Accuracy</strong>
-                    </div>
-                    <div class="d-flex align-items-center">
-                      <i class="bi bi-cash-stack me-2 text-primary"></i>
-                      <strong>40% Cost Reduction</strong>
-                    </div>
-                  </div>
-
-                  <p class="text-muted">
-                    Scalable temperature monitoring solution:
-                  </p>
-                  <ul class="text-muted small">
-                    <li>Real-time processing with Kafka pipelines</li>
-                    <li>LLM-enhanced forecasting models</li>
-                    <li>Looker dashboards for trend visualization</li>
-                    <li>Historical analysis via AWS</li>
-                  </ul>
-
-                  <div class="mt-auto">
-                    <a
-                      href="https://github.com/krishna-creator/Real-Time-IoT-Based-Temperature-Analytics-and-Forecasting"
-                      class="btn btn-primary px-3 py-2 me-2"
-                    >
-                      <i class="bi bi-github me-1"></i> Code
-                    </a>
-                    <a href="#" class="btn btn-outline-primary px-3 py-2">
-                      White Paper
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Project 4 - IntelliMeet -->
-            <div class="col-lg-8 col-xl-6 mb-5">
-              <div
-                class="card h-100 shadow-lg rounded-4 border-0 overflow-hidden"
-              >
-                <img
-                  src="assets/intellimeet.png"
-                  class="card-img-top img-fluid"
-                  alt="Video Conferencing"
-                  style="height: 250px; object-fit: cover"
-                />
-                <div class="card-body p-4">
-                  <div
-                    class="badge bg-primary bg-gradient-primary-to-secondary text-white rounded-pill mb-2"
-                  >
-                    AI/DevOps
-                  </div>
-                  <h2 class="fw-bolder mb-3">
-                    IntelliMeet: Secure Video Conferencing
-                  </h2>
-
-                  <div class="d-flex gap-2 mb-3">
-                    <span class="badge bg-light text-dark border">WebRTC</span>
-                    <span class="badge bg-light text-dark border">Node.js</span>
-                    <span class="badge bg-light text-dark border"
-                      >Federated Learning</span
-                    >
-                  </div>
-
-                  <div class="mb-4">
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-shield-lock me-2 text-primary"></i>
-                      <strong>Privacy-First Design</strong>
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-gpu-card me-2 text-primary"></i>
-                      <strong>25% Model Accuracy ↑</strong>
-                    </div>
-                    <div class="d-flex align-items-center">
-                      <i class="bi bi-lightning-charge me-2 text-primary"></i>
-                      <strong>&lt;200ms Latency</strong>
-                    </div>
-                  </div>
-
-                  <p class="text-muted">
-                    Decentralized communication platform:
-                  </p>
-                  <ul class="text-muted small">
-                    <li>On-device AI training</li>
-                    <li>83% accurate speech-to-text</li>
-                    <li>10+ concurrent users</li>
-                    <li>End-to-end encryption</li>
-                  </ul>
-
-                  <div class="mt-auto">
-                    <a
-                      href="https://github.com/krishna-creator/SE-Project---IntelliMeet"
-                      class="btn btn-primary px-3 py-2 me-2"
-                    >
-                      <i class="bi bi-github me-1"></i> Repo
-                    </a>
-                    <a href="#" class="btn btn-outline-primary px-3 py-2">
-                      Live Demo
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Project 5 - COVID Misinfo -->
-            <div class="col-lg-8 col-xl-6 mb-5">
-              <div
-                class="card h-100 shadow-lg rounded-4 border-0 overflow-hidden"
-              >
-                <img
-                  src="assets/fake.jpg"
-                  class="card-img-top img-fluid"
-                  alt="COVID Misinformation"
-                  style="height: 250px; object-fit: cover"
-                />
-                <div class="card-body p-4">
-                  <div
-                    class="badge bg-primary bg-gradient-primary-to-secondary text-white rounded-pill mb-2"
-                  >
-                    NLP Research
-                  </div>
-                  <h2 class="fw-bolder mb-3">
-                    COVID-19 Misinformation Tracking
-                  </h2>
-
-                  <div class="d-flex gap-2 mb-3">
-                    <span class="badge bg-light text-dark border">BERT</span>
-                    <span class="badge bg-light text-dark border">NLTK</span>
-                    <span class="badge bg-light text-dark border"
-                      >NetworkX</span
-                    >
-                  </div>
-
-                  <div class="mb-4">
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-twitter me-2 text-primary"></i>
-                      <strong>1M+ Tweets Analyzed</strong>
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-fingerprint me-2 text-primary"></i>
-                      <strong>89% Detection Accuracy</strong>
-                    </div>
-                  </div>
-
-                  <p class="text-muted">Social media analysis system:</p>
-                  <ul class="text-muted small">
-                    <li>LIAR dataset fine-tuning</li>
-                    <li>Community detection algorithms</li>
-                    <li>Sentiment analysis pipeline</li>
-                    <li>Influence tracking metrics</li>
-                  </ul>
-
-                  <div class="mt-auto">
-                    <a href="#" class="btn btn-primary px-3 py-2 me-2">
-                      <i class="bi bi-file-pdf me-1"></i> Paper
-                    </a>
-                    <a href="#" class="btn btn-outline-primary px-3 py-2">
-                      Dataset
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Project 6 - Talking Buddy -->
-            <div class="col-lg-8 col-xl-6 mb-5">
-              <div
-                class="card h-100 shadow-lg rounded-4 border-0 overflow-hidden"
-              >
-                <img
-                  src="assets/talking.jpg"
-                  class="card-img-top img-fluid"
-                  alt="AI Chatbot"
-                  style="height: 250px; object-fit: cover"
-                />
-                <div class="card-body p-4">
-                  <div
-                    class="badge bg-primary bg-gradient-primary-to-secondary text-white rounded-pill mb-2"
-                  >
-                    Conversational AI
-                  </div>
-                  <h2 class="fw-bolder mb-3">
-                    Talking Buddy: Emotional AI Companion
-                  </h2>
-
-                  <div class="d-flex gap-2 mb-3">
-                    <span class="badge bg-light text-dark border">GRU</span>
-                    <span class="badge bg-light text-dark border">React</span>
-                    <span class="badge bg-light text-dark border">Flask</span>
-                  </div>
-
-                  <div class="mb-4">
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-emoji-smile me-2 text-primary"></i>
-                      <strong>85% Sentiment Accuracy</strong>
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <i class="bi bi-lightning-charge me-2 text-primary"></i>
-                      <strong>23% Cost Reduction</strong>
-                    </div>
-                  </div>
-
-                  <p class="text-muted">Context-aware chatbot features:</p>
-                  <ul class="text-muted small">
-                    <li>68.7K parameter efficient model</li>
-                    <li>Real-time response generation</li>
-                    <li>Cross-platform compatibility</li>
-                    <li>Customer service integration</li>
-                  </ul>
-
-                  <div class="mt-auto">
-                    <a href="#" class="btn btn-primary px-3 py-2 me-2">
-                      <i class="bi bi-github me-1"></i> Source
-                    </a>
-                    <a href="#" class="btn btn-outline-primary px-3 py-2">
-                      Try Demo
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
+          <img src="https://via.placeholder.com/400x250?text=Proxy+TuNER" alt="Proxy TuNER" class="rounded mb-4" />
+          <h2 class="text-2xl font-semibold mb-2">Proxy TuNER</h2>
+          <p class="flex-grow">Proxy-tuning approach for cross-domain NER boosting F1 by 8% and reducing compute 70%.</p>
+          <a href="https://github.com/Krishna-dhulipalla" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
         </div>
-        <div
-          id="chatbot-lottie-btn"
-          onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/Personal_ChatBot', '_blank')"
-        >
-          <dotlottie-player
-            src="https://lottie.host/12b60265-5eef-4309-bcce-98abdae08afb/9FFDxA63EF.lottie"
-            background="transparent"
-            speed="1"
-            style="width: 50px; height: 50px"
-            loop
-            autoplay
-          ></dotlottie-player>
-          <div id="chatbot-lottie-btn-text">
-            Stuck scrolling? Chat with me instead!
-          </div>
+        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
+          <img src="https://via.placeholder.com/400x250?text=IntelliMeet" alt="IntelliMeet" class="rounded mb-4" />
+          <h2 class="text-2xl font-semibold mb-2">IntelliMeet</h2>
+          <p class="flex-grow">Decentralized video conferencing with on-device attention tracking and latency under 200ms.</p>
+          <a href="https://github.com/Krishna-dhulipalla" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
         </div>
-      </section>
-    </main>
-    <!-- Footer-->
-    <footer class="bg-white py-4 mt-auto">
-      <div class="container px-5">
-        <div
-          class="row align-items-center justify-content-between flex-column flex-sm-row"
-        >
-          <div class="col-auto">
-            <div class="small m-0">Copyright &copy; Krishna 2025</div>
-          </div>
-          <div class="col-auto">
-            <a class="small" href="contact.html">Contact</a>
-          </div>
+        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
+          <img src="https://via.placeholder.com/400x250?text=DNA+BERT" alt="DNA Project" class="rounded mb-4" />
+          <h2 class="text-2xl font-semibold mb-2">DNA Sequence Classifier</h2>
+          <p class="flex-grow">Fine-tuned DNABERT and HyenaDNA models achieving 94%+ accuracy on genomic tasks.</p>
+          <a href="https://github.com/Krishna-dhulipalla" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
+          <img src="https://via.placeholder.com/400x250?text=RAG+Search" alt="RAG Search" class="rounded mb-4" />
+          <h2 class="text-2xl font-semibold mb-2">Genomics Semantic Search</h2>
+          <p class="flex-grow">LangChain pipelines enabling retrieval over literature using lightweight embeddings.</p>
+          <a href="https://github.com/Krishna-dhulipalla" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
         </div>
       </div>
+    </section>
+
+    <footer class="py-6 text-center text-sm bg-white dark:bg-gray-900">
+      © <span id="year"></span> Krishna Vamsi Dhulipalla
     </footer>
-    <!-- Bootstrap core JS-->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Core theme JS-->
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Rebuilt portfolio pages (home, about, projects, resume) with Tailwind CSS and responsive dark/light mode
- Added style guide and theme toggler script for consistent branding
- Included placeholder resume download

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c6aa5bf0832296b0b61e30657f95