### PR TITLE
Refactor site for agentic ML focus and chatbot styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -35,18 +36,19 @@
         <img
           src="assets/profile.png"
           alt="Krishna Vamsi Dhulipalla"
-          class="w-40 h-40 rounded-full mb-4 shadow-lg"
+          class="w-48 h-48 md:w-60 md:h-60 rounded-full mb-4 shadow-lg object-cover"
         />
         <h1 class="text-4xl font-bold mb-2">About Me</h1>
       </div>
       <p class="max-w-3xl mx-auto mb-6 leading-relaxed">
-        I'm Krishna Vamsi Dhulipalla, a data engineer and machine learning enthusiast currently pursuing my MEng in Computer Science at
-        Virginia Tech. I love building systems that turn raw data into intelligent applications.
+        I'm Krishna Vamsi Dhulipalla, an agentic ML engineer pursuing my MEng in Computer Science at Virginia Tech. I love building
+        systems that turn raw data into autonomous applications.
       </p>
       <p class="max-w-3xl mx-auto mb-6 leading-relaxed">
-        My recent work spans AI research, data engineering, and deploying cloud-native ML solutions. I'm especially fascinated by the
-        intersection of AI with space exploration and bioinformatics, pushing the boundaries of how machine learning can drive
-        scientific discovery.
+        My recent work spans AI research, multi-agent orchestration and deploying cloud-native solutions. I work with LangGraph, AutoGen,
+        CrewAI, LangSmith and RAG pipelines powered by LangChain, often containerized with Docker and served via FastAPI. I'm especially
+        fascinated by the intersection of AI with space exploration and bioinformatics, pushing the boundaries of how machine learning
+        can drive scientific discovery.
       </p>
       <h2 class="text-2xl font-bold mt-12 mb-4">Education</h2>
       <ul class="list-disc ml-6 space-y-2">
@@ -62,9 +64,9 @@
 
     <footer class="py-6 text-center text-sm bg-white dark:bg-gray-900">
       © <span id="year"></span> Krishna Vamsi Dhulipalla
+    </footer>
     <div
       id="chatbot-lottie-btn"
-      class="fixed bottom-4 right-4 flex flex-col items-center cursor-pointer"
       onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/Personal_ChatBot', '_blank')"
     >
       <dotlottie-player
@@ -75,8 +77,8 @@
         loop
         autoplay
       ></dotlottie-player>
-      <div id="chatbot-lottie-btn-text" class="text-xs mt-1 text-gray-600 dark:text-gray-300">
-        Stuck scrolling? Chat with me instead!
+      <div id="chatbot-lottie-btn-text">
+        Chat with my LangGraph bot!
       </div>
     </div>
     <script>

--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="css/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -33,11 +34,6 @@
     </nav>
     <section class="py-16 px-6 md:px-12">
       <div class="flex flex-col items-center text-center mb-8">
-        <img
-          src="assets/profile.png"
-          alt="Krishna Vamsi Dhulipalla"
-          class="w-40 h-40 rounded-full mb-4 shadow-lg"
-        />
         <h1 class="text-4xl font-bold">Get in Touch</h1>
         <p class="text-gray-600 dark:text-gray-300">Let's work together!</p>
       </div>
@@ -91,7 +87,6 @@
     </footer>
     <div
       id="chatbot-lottie-btn"
-      class="fixed bottom-4 right-4 flex flex-col items-center cursor-pointer"
       onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/Personal_ChatBot', '_blank')"
     >
       <dotlottie-player
@@ -102,8 +97,8 @@
         loop
         autoplay
       ></dotlottie-player>
-      <div id="chatbot-lottie-btn-text" class="text-xs mt-1 text-gray-600 dark:text-gray-300">
-        Stuck scrolling? Chat with me instead!
+      <div id="chatbot-lottie-btn-text">
+        Chat with my LangGraph bot!
       </div>
     </div>
     <script>

--- a/css/styles.css
+++ b/css/styles.css
@@ -232,9 +232,10 @@ p {
   right: 20px;
   z-index: 9999;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  background-color: #ffffff;
-  border: 1px solid #ddd;
+  background-color: #0d9488;
+  border: none;
   border-radius: 30px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   padding: 8px 16px;
@@ -243,16 +244,16 @@ p {
 }
 
 #chatbot-lottie-btn:hover {
-  background-color: #f9f9f9;
+  background-color: #0f766e;
   transform: scale(1.03);
 }
 
 #chatbot-lottie-btn-text {
   font-family: "Segoe UI", sans-serif;
   font-size: 14px;
-  color: #333;
+  color: #ffffff;
   font-weight: 500;
-  margin-left: 10px;
+  margin-top: 8px;
   max-width: 200px;
 }
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -35,14 +36,9 @@
     <section class="relative flex items-center justify-center text-center py-24">
       <div class="absolute inset-0 -z-10 animate-gradient bg-gradient-to-r from-teal-500 via-purple-500 to-teal-500 opacity-20"></div>
       <div class="px-4 flex flex-col items-center">
-        <img
-          src="assets/profile.png"
-          alt="Krishna Vamsi Dhulipalla"
-          class="w-40 h-40 rounded-full mb-6 shadow-lg"
-        />
         <h1 class="text-4xl md:text-6xl font-bold">Krishna Vamsi Dhulipalla</h1>
-        <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Data Engineer & ML Enthusiast</p>
-        <p class="mt-2 text-gray-500 dark:text-gray-400">Building scalable data systems and AI models with impact.</p>
+        <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Agentic ML Engineer</p>
+        <p class="mt-2 text-gray-500 dark:text-gray-400">Building multi-agent systems with LangGraph, AutoGen, CrewAI, LangSmith and RAG-powered LangChain workflows.</p>
         <div class="mt-8">
           <a href="projects.html" class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow">View Projects</a>
           <a href="resume.html" class="ml-4 border border-teal-600 text-teal-600 dark:text-teal-400 hover:bg-teal-50 dark:hover:bg-gray-800 px-6 py-3 rounded">Resume</a>
@@ -54,9 +50,9 @@
     <section id="about" class="py-16 px-6 md:px-12">
       <h2 class="text-3xl font-bold mb-6">About Me</h2>
       <p class="max-w-3xl leading-relaxed">
-        I'm a graduate student pursuing an MEng in Computer Science at Virginia Tech. My work focuses on building robust data
-        pipelines and intelligent systems. I'm passionate about AI, space and bioinformatics research, and love turning complex
-        data challenges into scalable solutions.
+        I'm a graduate student pursuing an MEng in Computer Science at Virginia Tech. I build autonomous AI agents and
+        orchestrated pipelines using tools like LangGraph, AutoGen, CrewAI, LangSmith and RAG-driven LangChain. I'm passionate
+        about AI, space and bioinformatics research, and love turning complex challenges into scalable solutions.
       </p>
     </section>
 
@@ -64,18 +60,18 @@
     <section id="skills" class="py-16 px-6 md:px-12 bg-gray-50 dark:bg-gray-800">
       <h2 class="text-3xl font-bold mb-6 text-center">Skills & Tools</h2>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 max-w-4xl mx-auto">
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Python</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">SQL</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Spark</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Airflow</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">LangGraph</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">AutoGen</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">CrewAI</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">LangSmith</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">RAG</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">LangChain</div>
         <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Docker</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">FastAPI</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Python</div>
         <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">AWS</div>
         <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Hugging Face</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">LangChain</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">PyTorch</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">TensorFlow</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Kafka</div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">dbt</div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">Airflow</div>
       </div>
     </section>
 
@@ -99,7 +95,7 @@
           <p>Orchestrated genomic ETL pipelines and automated model retraining with custom CI/CD scripts.</p>
         </div>
         <div class="border-l-2 border-teal-600 pl-4">
-          <h3 class="text-xl font-semibold">Data Engineer – UJR Technologies</h3>
+          <h3 class="text-xl font-semibold">ML Engineer – UJR Technologies</h3>
           <p class="text-sm text-gray-500 dark:text-gray-400">Jul 2021 – Dec 2022</p>
           <p>Migrated batch ETL to real-time streaming and optimized Snowflake performance with materialized views.</p>
         </div>
@@ -111,6 +107,11 @@
       <h2 class="text-3xl font-bold mb-6 text-center">Featured Projects</h2>
       <div class="grid md:grid-cols-3 gap-6 max-w-5xl mx-auto">
         <div class="bg-white dark:bg-gray-700 rounded shadow p-4">
+          <img src="assets/talking.jpg" alt="LangGraph ChatBot" class="rounded mb-4" />
+          <h3 class="text-xl font-semibold mb-2">LangGraph ChatBot</h3>
+          <p class="text-sm">Graph-based LLM chatbot enabling multi-agent conversations with LangGraph.</p>
+        </div>
+        <div class="bg-white dark:bg-gray-700 rounded shadow p-4">
           <img src="assets/iot.png" alt="Android Agent" class="rounded mb-4" />
           <h3 class="text-xl font-semibold mb-2">LLM-Based Android Agent</h3>
           <p class="text-sm">Custom LLM agent achieving 80%+ step accuracy for mobile UI task automation.</p>
@@ -119,11 +120,6 @@
           <img src="assets/proxy.png" alt="Proxy TuNER" class="rounded mb-4" />
           <h3 class="text-xl font-semibold mb-2">Proxy TuNER</h3>
           <p class="text-sm">Proxy-tuned BERT models improving NER F1-score by 8% while cutting compute 70%.</p>
-        </div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4">
-          <img src="assets/intellimeet.png" alt="IntelliMeet" class="rounded mb-4" />
-          <h3 class="text-xl font-semibold mb-2">IntelliMeet</h3>
-          <p class="text-sm">Decentralized video conferencing with on-device attention tracking and low latency.</p>
         </div>
       </div>
       <div class="text-center mt-8">
@@ -145,7 +141,6 @@
     </footer>
     <div
       id="chatbot-lottie-btn"
-      class="fixed bottom-4 right-4 flex flex-col items-center cursor-pointer"
       onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/Personal_ChatBot', '_blank')"
     >
       <dotlottie-player
@@ -156,8 +151,8 @@
         loop
         autoplay
       ></dotlottie-player>
-      <div id="chatbot-lottie-btn-text" class="text-xs mt-1 text-gray-600 dark:text-gray-300">
-        Stuck scrolling? Chat with me instead!
+      <div id="chatbot-lottie-btn-text">
+        Chat with my LangGraph bot!
       </div>
     </div>
 

--- a/projects.html
+++ b/projects.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -31,14 +32,15 @@
 
     <section class="py-16 px-6 md:px-12">
       <div class="flex flex-col items-center text-center mb-12">
-        <img
-          src="assets/profile.png"
-          alt="Krishna Vamsi Dhulipalla"
-          class="w-40 h-40 rounded-full mb-4 shadow-lg"
-        />
         <h1 class="text-4xl font-bold">Projects</h1>
       </div>
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
+        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
+          <img src="assets/talking.jpg" alt="LangGraph ChatBot" class="rounded mb-4" />
+          <h2 class="text-2xl font-semibold mb-2">LangGraph ChatBot</h2>
+          <p class="flex-grow">Graph-based LLM chatbot enabling multi-agent conversations with LangGraph.</p>
+          <a href="https://github.com/krishna-dhulipalla/LangGraph_ChatBot" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
+        </div>
         <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
           <img src="assets/iot.png" alt="Android Agent" class="rounded mb-4" />
           <h2 class="text-2xl font-semibold mb-2">LLM-Based Android Agent</h2>
@@ -69,12 +71,6 @@
           <p class="flex-grow">LangChain pipelines enabling retrieval over literature using lightweight embeddings.</p>
           <a href="https://github.com/Krishna-dhulipalla" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
         </div>
-        <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
-          <img src="assets/talking.jpg" alt="LangGraph ChatBot" class="rounded mb-4" />
-          <h2 class="text-2xl font-semibold mb-2">LangGraph ChatBot</h2>
-          <p class="flex-grow">Graph-based LLM chatbot enabling multi-agent conversations with LangGraph.</p>
-          <a href="https://github.com/krishna-dhulipalla/LangGraph_ChatBot" class="mt-4 text-teal-600 dark:text-teal-400 underline">GitHub</a>
-        </div>
       </div>
     </section>
 
@@ -83,7 +79,6 @@
     </footer>
     <div
       id="chatbot-lottie-btn"
-      class="fixed bottom-4 right-4 flex flex-col items-center cursor-pointer"
       onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/Personal_ChatBot', '_blank')"
     >
       <dotlottie-player
@@ -94,8 +89,8 @@
         loop
         autoplay
       ></dotlottie-player>
-      <div id="chatbot-lottie-btn-text" class="text-xs mt-1 text-gray-600 dark:text-gray-300">
-        Stuck scrolling? Chat with me instead!
+      <div id="chatbot-lottie-btn-text">
+        Chat with my LangGraph bot!
       </div>
     </div>
     <script>

--- a/resume.html
+++ b/resume.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -31,14 +32,9 @@
 
     <section class="py-16 px-6 md:px-12">
       <div class="flex flex-col items-center text-center mb-8">
-        <img
-          src="assets/profile.png"
-          alt="Krishna Vamsi Dhulipalla"
-          class="w-40 h-40 rounded-full mb-4 shadow-lg"
-        />
         <h1 class="text-4xl font-bold">Resume</h1>
       </div>
-      <p class="mb-8 max-w-3xl mx-auto text-center">ML Engineer with 3+ years designing intelligent systems, deploying models and integrating backend infrastructure. Skilled in LLMs, data engineering and cloud-native deployments.</p>
+      <p class="mb-8 max-w-3xl mx-auto text-center">Agentic ML Engineer with 3+ years designing intelligent systems, deploying models and integrating backend infrastructure. Skilled in LLMs, autonomous agents and cloud-native deployments.</p>
       <a href="assets/resume.pdf" class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow">Download PDF</a>
 
       <h2 class="text-2xl font-bold mt-12 mb-4">Experience Highlights</h2>
@@ -46,11 +42,11 @@
         <li>ML Research Engineer, Cloud Systems LLC – built SQL and data pipelines and automated ETL workflows.</li>
         <li>ML Research Engineer, Virginia Tech – implemented DNA foundation models and automated preprocessing for massive genomic datasets.</li>
         <li>Research Assistant, Virginia Tech – orchestrated genomic ETL pipelines and CI/CD for model retraining.</li>
-        <li>Data Engineer, UJR Technologies – migrated ETL to real-time streaming and optimized Snowflake schemas.</li>
+        <li>ML Engineer, UJR Technologies – migrated ETL to real-time streaming and optimized Snowflake schemas.</li>
       </ul>
 
       <h2 class="text-2xl font-bold mt-12 mb-4">Core Skills</h2>
-      <p class="max-w-3xl">Python, SQL, Spark, Airflow, Kafka, Docker, AWS, Hugging Face, LangChain, PyTorch, TensorFlow, dbt.</p>
+      <p class="max-w-3xl">LangGraph, AutoGen, CrewAI, LangSmith, LangChain, RAG pipelines, Docker, FastAPI, Python, AWS.</p>
     </section>
 
     <footer class="py-6 text-center text-sm bg-white dark:bg-gray-900">
@@ -58,7 +54,6 @@
     </footer>
     <div
       id="chatbot-lottie-btn"
-      class="fixed bottom-4 right-4 flex flex-col items-center cursor-pointer"
       onclick="window.open('https://huggingface.co/spaces/krishnadhulipalla/Personal_ChatBot', '_blank')"
     >
       <dotlottie-player
@@ -69,8 +64,8 @@
         loop
         autoplay
       ></dotlottie-player>
-      <div id="chatbot-lottie-btn-text" class="text-xs mt-1 text-gray-600 dark:text-gray-300">
-        Stuck scrolling? Chat with me instead!
+      <div id="chatbot-lottie-btn-text">
+        Chat with my LangGraph bot!
       </div>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- Rebrand pages around an agentic ML engineer profile with updated hero copy and skills
- Highlight LangGraph ChatBot first in project listings and feature cards
- Style LangGraph chatbot button with teal theme and simplify layout

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d17158748322ae3441e279eb33b8