### PR TITLE
Expand portfolio content and enable dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/about.html
+++ b/about.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -77,24 +82,57 @@
         />
         <h1 class="text-4xl font-bold mb-2">About Me</h1>
       </div>
-      <p class="max-w-3xl mx-auto mb-6 leading-relaxed">
-        I'm Krishna Vamsi Dhulipalla, an agentic AI engineer currently pursuing
-        my MEng in Computer Science at Virginia Tech. I love building systems
-        that turn raw data into intelligent multi-agent applications.
-      </p>
-      <p class="max-w-3xl mx-auto mb-6 leading-relaxed">
-        My recent work spans AI research, agentic workflows, and deploying
-        cloud-native ML solutions using LangGraph, AutoGen, CrewAI, LangSmith,
-        and RAG with LangChain, Docker, and FastAPI. I'm especially fascinated
-        by the intersection of AI with space exploration and bioinformatics,
-        pushing the boundaries of how machine learning can drive scientific
-        discovery.
-      </p>
+        <p class="max-w-3xl mx-auto mb-6 leading-relaxed">
+          I'm Krishna Vamsi Dhulipalla, an ML engineer with 3+ years of
+          experience designing intelligent AI systems and cloud-native data
+          pipelines. Currently pursuing an M.S. in Computer Science at Virginia
+          Tech, I specialize in building LLM-driven agents and retrieval
+          workflows that turn raw data into actionable insights.
+        </p>
+        <p class="max-w-3xl mx-auto mb-6 leading-relaxed">
+          From automating mobile interfaces to accelerating genomic research, I
+          enjoy tackling complex problems with pragmatic solutions. My toolkit
+          includes LangChain, LangGraph, AutoGen, CrewAI, and a healthy dose of
+          Python and cloud infrastructure.
+        </p>
+        <h2 class="text-2xl font-bold mt-12 mb-4">Skills</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
+          <div>
+            <h3 class="font-semibold">Programming</h3>
+            <p>Python, R, SQL, JavaScript/TypeScript, Node.js</p>
+          </div>
+          <div>
+            <h3 class="font-semibold">Frameworks</h3>
+            <p>PyTorch, TensorFlow, Scikit-Learn, Hugging Face, LangChain, LangGraph</p>
+          </div>
+          <div>
+            <h3 class="font-semibold">AI Systems</h3>
+            <p>LLM Fine-Tuning, RAG, Prompt Engineering, Agents, GANs</p>
+          </div>
+          <div>
+            <h3 class="font-semibold">Cloud & Infra</h3>
+            <p>AWS, GCP, Docker, Kubernetes, SageMaker, MLflow</p>
+          </div>
+          <div>
+            <h3 class="font-semibold">Data Engineering</h3>
+            <p>Spark, Kafka, dbt, Airflow, ETL Pipelines, Data Warehousing</p>
+          </div>
+          <div>
+            <h3 class="font-semibold">Tools</h3>
+            <p>Pandas, NumPy, Weights & Biases, Git, Tableau, Linux</p>
+          </div>
+        </div>
       <h2 class="text-2xl font-bold mt-12 mb-4">Education</h2>
-      <ul class="list-disc ml-6 space-y-2">
-        <li>M.S. in Computer Science, Virginia Tech (2023–2024)</li>
-        <li>Bachelor's in Computer Science, Anna University (2018–2022)</li>
-      </ul>
+        <ul class="list-disc ml-6 space-y-2">
+          <li>
+            M.S. in Computer Science, Virginia Tech (Jan 2023 – Dec 2024), CGPA
+            3.95/4
+          </li>
+          <li>
+            Bachelor's in Computer Science, Anna University (Jul 2018 – May
+            2022), CGPA 8.24/10
+          </li>
+        </ul>
       <h2 class="text-2xl font-bold mt-12 mb-4">Interests</h2>
       <p class="max-w-3xl leading-relaxed">
         AI systems, space technologies, and bioinformatics research excite me.

--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -70,7 +75,7 @@
       <div class="flex flex-col items-center text-center mb-8">
         <h1 class="text-4xl font-bold">Get in Touch</h1>
         <p class="text-gray-600 dark:text-gray-300">
-          Let's build agentic AI together!
+          Have a project or role focused on LLMs, data engineering, or intelligent agents? Let's connect and build something impactful.
         </p>
       </div>
       <form

--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -92,11 +97,13 @@
       <div class="px-4 flex flex-col items-center">
         <h1 class="text-4xl md:text-6xl font-bold">Krishna Vamsi Dhulipalla</h1>
         <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">
-          Agentic AI Engineer
+          ML engineer specializing in agentic workflows and LLM applications.
         </p>
-        <p class="mt-2 text-gray-500 dark:text-gray-400">
-          Building agentic systems with LangGraph, AutoGen, CrewAI, LangSmith,
-          and RAG pipelines using LangChain, Docker, and FastAPI.
+        <p class="mt-2 text-gray-500 dark:text-gray-400 max-w-2xl">
+          3+ years of experience designing intelligent systems, deploying
+          models, and integrating cloud-native backends. Focused on
+          LLM-powered agents, semantic search, and real-time data using
+          LangChain, LangGraph, and FastAPI.
         </p>
         <div class="mt-8">
           <a
@@ -115,15 +122,15 @@
 
     <!-- About -->
     <section id="about" class="py-16 px-6 md:px-12">
-      <h2 class="text-3xl font-bold mb-6">About Me</h2>
-      <p class="max-w-3xl leading-relaxed">
-        I'm a graduate student pursuing an MEng in Computer Science at Virginia
-        Tech. My work focuses on crafting agentic workflows and intelligent
-        systems with tools like LangGraph, AutoGen, CrewAI, LangSmith, and RAG
-        with LangChain, Docker, and FastAPI. I'm passionate about AI, space and
-        bioinformatics research, and love turning complex challenges into
-        scalable solutions.
-      </p>
+        <h2 class="text-3xl font-bold mb-6">About Me</h2>
+        <p class="max-w-3xl leading-relaxed">
+          ML engineer with 3+ years building end-to-end AI solutions—from data
+          ingestion and model training to production deployment. Experienced
+          across ML research, infrastructure, and backend development with a
+          strong focus on LLM agents, semantic retrieval, and modular reasoning.
+          I enjoy translating complex problems into scalable, real-world
+          applications.
+        </p>
     </section>
 
     <!-- Skills -->
@@ -165,12 +172,27 @@
         <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
           SQL
         </div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
-          PyTorch
-        </div>
-        <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
-          TensorFlow
-        </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            PyTorch
+          </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            TensorFlow
+          </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            AWS
+          </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            GCP
+          </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            Kubernetes
+          </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            Spark
+          </div>
+          <div class="bg-white dark:bg-gray-700 rounded shadow p-4 text-center">
+            Kafka
+          </div>
       </div>
     </section>
 
@@ -182,47 +204,51 @@
           <h3 class="text-xl font-semibold">
             ML Research Engineer – Cloud Systems LLC
           </h3>
-          <p class="text-sm text-gray-500 dark:text-gray-400">
-            Jul 2024 – Present
-          </p>
-          <p>
-            Designed complex SQL and data pipelines, building automated ETL
-            workflows for diverse sources.
-          </p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Jul 2024 – Present
+            </p>
+            <p>
+              Developed high-volume SQL queries and streaming pipelines,
+              automating ETL across cloud datasets to deliver reliable analytics
+              in near real time.
+            </p>
         </div>
         <div class="border-l-2 border-teal-600 pl-4">
           <h3 class="text-xl font-semibold">
             ML Research Engineer – Virginia Tech
           </h3>
-          <p class="text-sm text-gray-500 dark:text-gray-400">2024</p>
-          <p>
-            Built AI pipelines with DNA foundation models and automated
-            preprocessing for 1M+ sequences.
-          </p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Sep 2024 – Jul 2024</p>
+            <p>
+              Fine-tuned DNABERT and HyenaDNA models with LoRA and soft
+              prompting, reaching 94%+ accuracy while cutting iteration cycles by
+              40%.
+            </p>
         </div>
         <div class="border-l-2 border-teal-600 pl-4">
           <h3 class="text-xl font-semibold">
             Research Assistant – Virginia Tech
           </h3>
-          <p class="text-sm text-gray-500 dark:text-gray-400">
-            Jun 2023 – May 2024
-          </p>
-          <p>
-            Orchestrated genomic ETL pipelines and automated model retraining
-            with custom CI/CD scripts.
-          </p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Jun 2023 – May 2024
+            </p>
+            <p>
+              Orchestrated genomic ETL pipelines with Airflow and Glue,
+              automating model retraining to boost data availability 50% and cut
+              manual effort 40%.
+            </p>
         </div>
         <div class="border-l-2 border-teal-600 pl-4">
           <h3 class="text-xl font-semibold">
             Agentic Engineer – UJR Technologies
           </h3>
-          <p class="text-sm text-gray-500 dark:text-gray-400">
-            Jul 2021 – Dec 2022
-          </p>
-          <p>
-            Migrated batch ETL to real-time streaming and optimized Snowflake
-            performance with materialized views.
-          </p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Jul 2021 – Dec 2022
+            </p>
+            <p>
+              Migrated batch jobs to Kafka/Spark streaming and redesigned
+              Snowflake schemas, cutting query latency 40% and accelerating
+              deployments by 25%.
+            </p>
         </div>
       </div>
     </section>

--- a/projects.html
+++ b/projects.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -79,10 +84,11 @@
             class="rounded mb-4"
           />
           <h2 class="text-2xl font-semibold mb-2">LangGraph ChatBot</h2>
-          <p class="flex-grow">
-            Graph-based LLM chatbot enabling multi-agent conversations with
-            LangGraph.
-          </p>
+          <ul class="list-disc pl-5 text-sm flex-grow space-y-1">
+            <li><strong>Context:</strong> Explore multi-agent coordination for conversational AI.</li>
+            <li><strong>Actions:</strong> Built a graph-based chatbot orchestrating LLM agents with LangGraph for tool use and role handoffs.</li>
+            <li><strong>Impact:</strong> Demonstrated a scalable pattern for multi-agent dialogues and reasoning.</li>
+          </ul>
           <a
             href="https://github.com/krishna-dhulipalla/LangGraph_ChatBot"
             class="mt-4 text-teal-600 dark:text-teal-400 underline"
@@ -92,10 +98,11 @@
         <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
           <img src="assets/iot.png" alt="Android Agent" class="rounded mb-4" />
           <h2 class="text-2xl font-semibold mb-2">LLM-Based Android Agent</h2>
-          <p class="flex-grow">
-            Android UI automation agent with modular prompting and memory,
-            reaching 80%+ step accuracy.
-          </p>
+          <ul class="list-disc pl-5 text-sm flex-grow space-y-1">
+            <li><strong>Context:</strong> Automate mobile UI tasks from natural language goals.</li>
+            <li><strong>Actions:</strong> Engineered a custom LLM agent with few-shot prompting, memory buffers, and self-reflection to interpret layouts and goals.</li>
+            <li><strong>Impact:</strong> Achieved 80%+ step accuracy across 10+ simulated apps and improved goal success rate by ~25%.</li>
+          </ul>
           <a
             href="https://github.com/Krishna-dhulipalla"
             class="mt-4 text-teal-600 dark:text-teal-400 underline"
@@ -105,10 +112,11 @@
         <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
           <img src="assets/proxy.png" alt="Proxy TuNER" class="rounded mb-4" />
           <h2 class="text-2xl font-semibold mb-2">Proxy TuNER</h2>
-          <p class="flex-grow">
-            Proxy-tuning approach for cross-domain NER boosting F1 by 8% and
-            reducing compute 70%.
-          </p>
+          <ul class="list-disc pl-5 text-sm flex-grow space-y-1">
+            <li><strong>Context:</strong> Improve cross-domain NER without large compute budgets.</li>
+            <li><strong>Actions:</strong> Developed proxy-tuning for BERT using logit ensembling and gradient reversal layers.</li>
+            <li><strong>Impact:</strong> Raised average F1 by 8%, cut computation 70%, and sped inference 30%.</li>
+          </ul>
           <a
             href="https://github.com/Krishna-dhulipalla"
             class="mt-4 text-teal-600 dark:text-teal-400 underline"
@@ -122,10 +130,11 @@
             class="rounded mb-4"
           />
           <h2 class="text-2xl font-semibold mb-2">IntelliMeet</h2>
-          <p class="flex-grow">
-            Decentralized video conferencing with on-device attention tracking
-            and latency under 200ms.
-          </p>
+          <ul class="list-disc pl-5 text-sm flex-grow space-y-1">
+            <li><strong>Context:</strong> Create a secure, decentralized video conferencing platform.</li>
+            <li><strong>Actions:</strong> Built federated, encrypted system with on-device RetinaFace attention tracking and Transformer-based speech-to-text.</li>
+            <li><strong>Impact:</strong> Delivered sub-200ms latency, boosted meeting engagement 25%, and maintained 99.9% uptime.</li>
+          </ul>
           <a
             href="https://github.com/Krishna-dhulipalla"
             class="mt-4 text-teal-600 dark:text-teal-400 underline"
@@ -135,10 +144,11 @@
         <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
           <img src="assets/fake.jpg" alt="DNA Project" class="rounded mb-4" />
           <h2 class="text-2xl font-semibold mb-2">DNA Sequence Classifier</h2>
-          <p class="flex-grow">
-            Fine-tuned DNABERT and HyenaDNA models achieving 94%+ accuracy on
-            genomic tasks.
-          </p>
+          <ul class="list-disc pl-5 text-sm flex-grow space-y-1">
+            <li><strong>Context:</strong> Classify genomic sequences accurately with limited compute.</li>
+            <li><strong>Actions:</strong> Fine-tuned DNABERT and HyenaDNA with LoRA and soft prompting; automated preprocessing for 1M+ sequences via Biopython and Airflow.</li>
+            <li><strong>Impact:</strong> Reached 94%+ accuracy and cut preprocessing runtime by 40%.</li>
+          </ul>
           <a
             href="https://github.com/Krishna-dhulipalla"
             class="mt-4 text-teal-600 dark:text-teal-400 underline"
@@ -148,10 +158,11 @@
         <div class="bg-white dark:bg-gray-800 rounded shadow p-6 flex flex-col">
           <img src="assets/drone.jpg" alt="RAG Search" class="rounded mb-4" />
           <h2 class="text-2xl font-semibold mb-2">Genomics Semantic Search</h2>
-          <p class="flex-grow">
-            LangChain pipelines enabling retrieval over literature using
-            lightweight embeddings.
-          </p>
+          <ul class="list-disc pl-5 text-sm flex-grow space-y-1">
+            <li><strong>Context:</strong> Enable efficient discovery across genomics literature.</li>
+            <li><strong>Actions:</strong> Built LangChain pipelines with local embeddings and vector indexes for semantic retrieval.</li>
+            <li><strong>Impact:</strong> Streamlined literature reviews with fast, context-aware search results.</li>
+          </ul>
           <a
             href="https://github.com/Krishna-dhulipalla"
             class="mt-4 text-teal-600 dark:text-teal-400 underline"

--- a/resume.html
+++ b/resume.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script
       src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs"
@@ -71,43 +76,96 @@
       <div class="flex flex-col items-center text-center mb-8">
         <h1 class="text-4xl font-bold">Resume</h1>
       </div>
-      <p class="mb-8 max-w-3xl mx-auto text-center">
-        Agentic AI Engineer with 3+ years designing multi-agent systems,
-        deploying models and integrating backend infrastructure. Skilled in
-        LangGraph, AutoGen, CrewAI, LangSmith, RAG with LangChain, Docker,
-        FastAPI, and cloud-native deployments.
-      </p>
-      <a
-        href="assets/resume.pdf"
-        class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow"
-        >Download PDF</a
-      >
+        <p class="mb-8 max-w-3xl mx-auto text-center">
+          ML engineer with 3+ years designing intelligent AI systems, deploying
+          models, and integrating cloud-native infrastructure. Experienced across
+          ML research, data engineering, and backend development with a focus on
+          LLM agents, semantic search, and real-time analytics.
+        </p>
+        <a
+          href="assets/resume.pdf"
+          class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded shadow"
+          >Download PDF</a
+        >
 
-      <h2 class="text-2xl font-bold mt-12 mb-4">Experience Highlights</h2>
-      <ul class="list-disc ml-6 space-y-2 max-w-3xl">
-        <li>
-          ML Research Engineer, Cloud Systems LLC – built SQL and agentic
-          pipelines and automated ETL workflows.
-        </li>
-        <li>
-          ML Research Engineer, Virginia Tech – implemented DNA foundation
-          models and automated preprocessing for massive genomic datasets.
-        </li>
-        <li>
-          Research Assistant, Virginia Tech – orchestrated genomic ETL pipelines
-          and CI/CD for model retraining.
-        </li>
-        <li>
-          Agentic Engineer, UJR Technologies – migrated ETL to real-time
-          streaming and optimized Snowflake schemas.
-        </li>
-      </ul>
+        <h2 class="text-2xl font-bold mt-12 mb-4">Work Experience</h2>
+        <div class="space-y-6 max-w-3xl">
+          <div>
+            <h3 class="text-xl font-semibold">ML Research Engineer – Cloud Systems LLC</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Jul 2024 – Present | Remote</p>
+            <ul class="list-disc pl-5 space-y-1">
+              <li><strong>Context:</strong> Modernize analytics for diverse cloud datasets.</li>
+              <li><strong>Actions:</strong> Created optimized SQL queries and streaming pipelines, automating ETL across sources with Airflow.</li>
+              <li><strong>Impact:</strong> Delivered reliable data feeds and reduced manual prep by 40%.</li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold">ML Research Engineer – Virginia Tech</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Sep 2024 – Jul 2024 | Blacksburg, VA</p>
+            <ul class="list-disc pl-5 space-y-1">
+              <li><strong>Context:</strong> Classify genomic sequences using DNA foundation models.</li>
+              <li><strong>Actions:</strong> Fine-tuned DNABERT and HyenaDNA with LoRA and soft prompting; automated preprocessing for 1M+ sequences using Biopython and Airflow.</li>
+              <li><strong>Impact:</strong> Reached 94%+ accuracy and cut iteration cycles by 40%.</li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold">Research Assistant – Virginia Tech</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Jun 2023 – May 2024 | Blacksburg, VA</p>
+            <ul class="list-disc pl-5 space-y-1">
+              <li><strong>Context:</strong> Support genomic research with scalable data workflows.</li>
+              <li><strong>Actions:</strong> Orchestrated ETL pipelines with Airflow and Glue, and automated model retraining via custom CI/CD scripts.</li>
+              <li><strong>Impact:</strong> Improved data availability 50% while reducing manual effort 40%.</li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold">Data Engineer – UJR Technologies Pvt Ltd</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Jul 2021 – Dec 2022 | Hyderabad, India</p>
+            <ul class="list-disc pl-5 space-y-1">
+              <li><strong>Context:</strong> Transition legacy data platform to real-time analytics.</li>
+              <li><strong>Actions:</strong> Migrated batch jobs to Kafka/Spark streaming and optimized Snowflake schemas with materialized views.</li>
+              <li><strong>Impact:</strong> Cut processing latency 30%, sped deployments 25%, and maintained 99.9% uptime.</li>
+            </ul>
+          </div>
+        </div>
 
-      <h2 class="text-2xl font-bold mt-12 mb-4">Core Skills</h2>
-      <p class="max-w-3xl">
-        LangGraph, LangChain, AutoGen, CrewAI, LangSmith, RAG, Docker, FastAPI,
-        Python, SQL, PyTorch, TensorFlow.
-      </p>
+        <h2 class="text-2xl font-bold mt-12 mb-4">Skills</h2>
+        <ul class="list-disc ml-6 space-y-1 max-w-3xl">
+          <li><strong>Programming:</strong> Python, R, SQL, JavaScript/TypeScript, Node.js</li>
+          <li><strong>Frameworks:</strong> PyTorch, TensorFlow, Scikit-Learn, Hugging Face Transformers, LangChain, LangGraph</li>
+          <li><strong>AI Systems:</strong> LLM Fine-Tuning, RAG, Prompt Engineering, Agents, GANs</li>
+          <li><strong>Cloud & Infra:</strong> AWS, GCP, Docker, Kubernetes, SageMaker, MLflow, CI/CD</li>
+          <li><strong>Data Engineering:</strong> Spark, Kafka, dbt, Airflow, ETL pipelines, Data Warehousing</li>
+          <li><strong>Tools:</strong> Pandas, NumPy, Weights & Biases, Git, Tableau, Linux</li>
+        </ul>
+
+        <h2 class="text-2xl font-bold mt-12 mb-4">Education</h2>
+        <ul class="list-disc ml-6 space-y-2 max-w-3xl">
+          <li>M.S. in Computer Science, Virginia Tech (Jan 2023 – Dec 2024) – CGPA 3.95/4</li>
+          <li>Bachelor’s in Computer Science, Anna University (Jul 2018 – May 2022) – CGPA 8.24/10</li>
+        </ul>
+
+        <h2 class="text-2xl font-bold mt-12 mb-4">Publications</h2>
+        <ul class="list-disc ml-6 space-y-2 max-w-3xl">
+          <li>
+            L. Miao, K. V. Dhulipalla, S. Kundu et al., "Leveraging Machine
+            Learning for Predicting Circadian Transcription in mRNAs and lncRNAs," IEEE BIBM 2024.
+          </li>
+          <li>
+            M. Haghani, K. V. Dhulipalla, S. Li, "Harnessing DNA Foundation Models
+            for Cross-Species Transcription Factor Binding Sites Prediction in Plant Genomes," ML in Computational Biology 2025.
+          </li>
+        </ul>
+
+        <h2 class="text-2xl font-bold mt-12 mb-4">Certifications</h2>
+        <ul class="list-disc ml-6 space-y-1 max-w-3xl">
+          <li>Building RAG Agents with LLMs – Nvidia</li>
+          <li>Introduction to Deploying RAG Pipelines for Production at Scale</li>
+          <li>Delivering Data-Driven Decisions with AWS</li>
+          <li>End-to-End Real-World Data Engineering with Snowflake</li>
+          <li>Google Cloud Data Engineering Foundations</li>
+          <li>AICTE-EduSkills Certificate in AWS Cloud</li>
+          <li>Coursera Machine Learning (Data-Driven Insights, ML Algorithms)</li>
+        </ul>
     </section>
 
     <footer class="py-6 text-center text-sm bg-white dark:bg-gray-900">


### PR DESCRIPTION
## Summary
- enable class-based dark theme support across all pages
- enrich about and resume sections with detailed background, skills, and education
- add context-action-impact details for each project card

## Testing
- `npm test` *(fails: jest-environment-jsdom package missing)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1000e64c0832296b4324143d205e9