### PR TITLE
Add Home navigation link and fix theme toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,6 +45,11 @@
       >
       <div class="space-x-4 text-sm md:text-base">
         <a
+          href="index.html"
+          class="hover:text-teal-600 dark:hover:text-teal-400"
+          >Home</a
+        >
+        <a
           href="about.html"
           class="hover:text-teal-600 dark:hover:text-teal-400"
           >About</a

--- a/contact.html
+++ b/contact.html
@@ -44,6 +44,11 @@
       >
       <div class="space-x-4 text-sm md:text-base">
         <a
+          href="index.html"
+          class="hover:text-teal-600 dark:hover:text-teal-400"
+          >Home</a
+        >
+        <a
           href="about.html"
           class="hover:text-teal-600 dark:hover:text-teal-400"
           >About</a

--- a/index.html
+++ b/index.html
@@ -59,6 +59,11 @@
       >
       <div class="space-x-4 text-sm md:text-base">
         <a
+          href="index.html"
+          class="hover:text-teal-600 dark:hover:text-teal-400"
+          >Home</a
+        >
+        <a
           href="about.html"
           class="hover:text-teal-600 dark:hover:text-teal-400"
           >About</a

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,21 +1,32 @@
-function toggleTheme() {
-  const root = document.documentElement;
-  const isDark = root.classList.contains('dark');
-  if (isDark) {
-    root.classList.remove('dark');
-    localStorage.theme = 'light';
+function setThemeFromStorage() {
+  if (localStorage.theme === 'dark') {
+    document.documentElement.classList.add('dark');
   } else {
-    root.classList.add('dark');
-    localStorage.theme = 'dark';
+    document.documentElement.classList.remove('dark');
   }
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  if (localStorage.theme === 'dark') {
-    document.documentElement.classList.add('dark');
-  }
+function updateToggleIcon() {
   const toggle = document.getElementById('theme-toggle');
   if (toggle) {
+    toggle.textContent = document.documentElement.classList.contains('dark')
+      ? '🌞'
+      : '🌙';
+  }
+}
+
+function toggleTheme() {
+  const isDark = document.documentElement.classList.toggle('dark');
+  localStorage.theme = isDark ? 'dark' : 'light';
+  updateToggleIcon();
+}
+
+setThemeFromStorage();
+
+window.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  if (toggle) {
+    updateToggleIcon();
     toggle.addEventListener('click', toggleTheme);
   }
 });

--- a/projects.html
+++ b/projects.html
@@ -44,6 +44,11 @@
       >
       <div class="space-x-4 text-sm md:text-base">
         <a
+          href="index.html"
+          class="hover:text-teal-600 dark:hover:text-teal-400"
+          >Home</a
+        >
+        <a
           href="about.html"
           class="hover:text-teal-600 dark:hover:text-teal-400"
           >About</a

--- a/resume.html
+++ b/resume.html
@@ -44,6 +44,11 @@
       >
       <div class="space-x-4 text-sm md:text-base">
         <a
+          href="index.html"
+          class="hover:text-teal-600 dark:hover:text-teal-400"
+          >Home</a
+        >
+        <a
           href="about.html"
           class="hover:text-teal-600 dark:hover:text-teal-400"
           >About</a


### PR DESCRIPTION
## Summary
- Add explicit Home link to the navigation bar across all pages
- Fix and enhance theme toggle behavior with persistent storage and icons

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49041b36083229f0b47f2891a60ae