### PR TITLE
Improve light theme and hero sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,8 +10,8 @@ body {
   backdrop-filter: blur(8px);
   background: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.6),
-    rgba(255, 255, 255, 0.35)
+    rgba(255, 255, 255, 0.85),
+    rgba(255, 255, 255, 0.65)
   );
 }
 .dark .glass {

--- a/index.html
+++ b/index.html
@@ -149,11 +149,11 @@
           </div>
         </div>
         <div class="relative" data-aos="fade-up" data-aos-delay="150">
-          <div class="rounded-2xl shadow-float p-4 glass">
+          <div class="rounded-2xl shadow-float p-4 glass h-[340px] overflow-hidden">
             <!-- Use a local .lottie or .json you control; this avoids 403s -->
             <dotlottie-wc
               src="https://lottie.host/ec759afa-08cf-493a-9df6-4f2ba2a515fe/01ooaS1eRs.lottie"
-              style="width: 100%; height: 100%"
+              class="w-full h-full object-cover"
               speed="1"
               autoplay
               loop
@@ -213,7 +213,7 @@
     </section>
 
     <!-- ===== Featured Projects ===== -->
-    <section id="projects" class="bg-gray-50 dark:bg-gray-800/40">
+    <section id="projects" class="bg-white dark:bg-gray-800/40">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20">
         <div class="flex items-end justify-between gap-6">
           <h2 class="font-display text-3xl md:text-4xl font-bold">
@@ -573,7 +573,7 @@
     </section>
 
     <!-- ===== Skills ===== -->
-    <section id="skills" class="bg-gray-50 dark:bg-gray-800/40">
+    <section id="skills" class="bg-white dark:bg-gray-800/40">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20">
         <h2 class="font-display text-3xl md:text-4xl font-bold">
           Skills & tools


### PR DESCRIPTION
## Summary
- lighten glass overlay so light mode appears crisp
- ensure hero animation fills its container
- use white backgrounds for project and skills sections

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb28f65b948322b15ab87a2f5ae6b2