### PR TITLE
Improve light theme and hero sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,18 +8,10 @@ body {
 
 .glass {
   backdrop-filter: blur(8px);
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.6),
-    rgba(255, 255, 255, 0.35)
-  );
+  background-color: #ffffff;
 }
 .dark .glass {
-  background: linear-gradient(
-    180deg,
-    rgba(17, 24, 39, 0.7),
-    rgba(17, 24, 39, 0.5)
-  );
+  background-color: rgba(17, 24, 39, 0.6);
 }
 .accent-gradient {
   background-image: linear-gradient(90deg, #14b8a6, #7c3aed, #14b8a6);
@@ -94,7 +86,7 @@ body {
 .j-body {
   border-radius: 18px;
   border: 1px solid rgba(0, 0, 0, 0.06);
-  background: rgba(255, 255, 255, 0.75);
+  background: #ffffff;
   backdrop-filter: blur(8px);
   padding: 1.1rem 1.25rem;
   box-shadow: 0 30px 70px -40px rgba(0, 0, 0, 0.35);
@@ -202,8 +194,8 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   background: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.6),
-    rgba(255, 255, 255, 0.35)
+    rgba(255, 255, 255, 0.9),
+    rgba(255, 255, 255, 0.7)
   );
 }
 .dark .theme-toggle {

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
   <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <!-- ===== Navbar ===== -->
     <header
-      class="fixed top-0 inset-x-0 z-50 border-b border-black/5 dark:border-white/10 bg-white/80 dark:bg-gray-900/80 glass"
+      class="fixed top-0 inset-x-0 z-50 border-b border-black/5 dark:border-white/10 bg-white dark:bg-gray-900/80 glass"
     >
       <nav
         class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between"
@@ -149,11 +149,13 @@
           </div>
         </div>
         <div class="relative" data-aos="fade-up" data-aos-delay="150">
-          <div class="rounded-2xl shadow-float p-4 glass">
+          <div class="rounded-2xl shadow-float p-4 bg-white dark:bg-gray-900 h-[340px] overflow-hidden">
             <!-- Use a local .lottie or .json you control; this avoids 403s -->
             <dotlottie-wc
+              id="heroAnim"
               src="https://lottie.host/ec759afa-08cf-493a-9df6-4f2ba2a515fe/01ooaS1eRs.lottie"
-              style="width: 100%; height: 100%"
+              class="w-full h-full object-cover"
+              style="width:100%;height:100%"
               speed="1"
               autoplay
               loop
@@ -213,7 +215,7 @@
     </section>
 
     <!-- ===== Featured Projects ===== -->
-    <section id="projects" class="bg-gray-50 dark:bg-gray-800/40">
+    <section id="projects" class="bg-white dark:bg-gray-800/40">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20">
         <div class="flex items-end justify-between gap-6">
           <h2 class="font-display text-3xl md:text-4xl font-bold">
@@ -573,7 +575,7 @@
     </section>
 
     <!-- ===== Skills ===== -->
-    <section id="skills" class="bg-gray-50 dark:bg-gray-800/40">
+    <section id="skills" class="bg-white dark:bg-gray-800/40">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20">
         <h2 class="font-display text-3xl md:text-4xl font-bold">
           Skills & tools
@@ -660,7 +662,7 @@
           id="nn-contact-form"
           action="https://formspree.io/f/mzzpwpkj"
           method="POST"
-          class="rounded-2xl border border-gray-200 dark:border-gray-700 p-6 grid gap-4 bg-white/80 dark:bg-gray-900/50 glass"
+          class="rounded-2xl border border-gray-200 dark:border-gray-700 p-6 grid gap-4 bg-white dark:bg-gray-900/50"
           onsubmit="event.preventDefault(); showToast('Message sent — I will reply soon.'); this.reset();"
         >
           <div class="grid gap-1">


### PR DESCRIPTION
## Summary
- remove gray tint from glass surfaces so light mode stays bright
- ensure hero animation fills its card and exposes an id for fallback
- keep contact form crisp by dropping the glass overlay

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden - registry access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68bb28f65b948322b15ab87a2f5ae6b2